### PR TITLE
Update LeadDeveloper.md to split out bullet point for consistency with other software job descriptions

### DIFF
--- a/Software Developers/LeadDeveloper.md
+++ b/Software Developers/LeadDeveloper.md
@@ -43,8 +43,10 @@ Read more about software development on the
  * Experience championing practices such as Test-Driven Development, CI/CD, and DevOps as well as modern development workflows, ideally using GitHub
  
  * A cloud-first approach and experience of IaaS and PaaS solutions as well as understanding infrastructure-as-code and containerisation
+ 
+ * Experience of good software design principles such as OOD, SOLID and design patterns
 
- * Experience of good software design principles such as OOD, SOLID, RESTful API design and loosely coupled microservices architectures
+ * Experience of RESTful API design and loosely coupled microservices architectures
 
  * A good understanding of web application security and awareness of the OWASP Top 10 security vulnerabilities
 


### PR DESCRIPTION
### Background/Overview

Currently, the lead developer job description has OOD/SOLID/RESTful API design/microservices on the same line.

All other role descriptions (more and less senior) which specify these, have them split out into two lines. 

I link to the relevant lines of code below, for convenience.

- **Junior Developer**
  - Not explicitly referred to

- **Software Developer**
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/Software%20Developers/SoftwareDeveloper.md?plain=1#L37-L39

- **Senior Developer** 
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/Software%20Developers/SeniorDeveloper.md?plain=1#L41-L43

- **Lead Developer**
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/Software%20Developers/LeadDeveloper.md?plain=1#L47

- **Principal Developer**
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/Software%20Developers/PrincipalDeveloper.md?plain=1#L52-L54

### Proposed Changes

- This pull request amends the lead developer job description to be consistent with the suite of other job descriptions.