### PR TITLE
Update display name for PR workflow, to indicate it builds only (no deployment occurs on PR)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Deploy Middleman to GH Pages
+name: Build Middleman to GH Pages
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
### Background/Overview

- On a recent PR I noticed that GitHub reports that the proposed change is being deployed.
  - <img width="614" alt="image" src="https://user-images.githubusercontent.com/96429508/213859995-6e15a408-ec9d-4d38-9f3c-4a91cc06d4d1.png">

- Being the curious chap I am and taking advantage our example of coding in the open(! 😉), I looked closer to see where it is being deployed to and noticed that the workflow is actually build-only...
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/.github/workflows/pr.yml
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/.github/workflows/pr.yml#L1-L7

- ... instead, build and deploy appears to happen within `gh-pages.yml` which is triggered on merges into `main` (and the deploy step is confirmed as being absent from `pr.yml`).
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/.github/workflows/gh-pages.yml#L1-L8
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/.github/workflows/gh-pages.yml#L25-L34


### Proposed changes

- Update the display name of the workflow, to indicate it only builds (no deployment occurs)