### PR TITLE
Update list of programming language names to remove duplication and improve consistency

### DIFF
--- a/Software Developers/JuniorDeveloper.md
+++ b/Software Developers/JuniorDeveloper.md
@@ -31,7 +31,7 @@ Read more about software development on the
 
  * Enthusiasm to learn new things   
 
- * An interest in software development, ideally with some experience of C#.Net, Ruby, or similar.    
+ * An interest in software development, ideally with some experience of C#/.Net, Ruby, or similar.    
 
  * Ability to use automated tests to continuously validate your work.    
 

--- a/Software Developers/SeniorDeveloper.md
+++ b/Software Developers/SeniorDeveloper.md
@@ -30,7 +30,7 @@ Read more about software development on the
 
 ### Essential:
 
- * Expert knowledge of software development using (Ruby and the Ruby on Rails framework/ C#.NET / Ruby and the Ruby on Rails framework, C#/.NET, or similar)
+ * Expert knowledge of software development using (Ruby and the Ruby on Rails framework, C#/.NET, or similar)
   
  * Experience leading by example working with technical teams to deliver user-focused services in an agile environment
    

--- a/Software Developers/SoftwareDeveloper.md
+++ b/Software Developers/SoftwareDeveloper.md
@@ -28,7 +28,7 @@ Read more about software development on the
 
 ### Essential: 
 
- * Good knowledge of software development using (Ruby and the Ruby on Rails framework/ C#/.NET / Ruby and the Ruby on Rails framework, C#/.NET, or similar)
+ * Good knowledge of software development using (Ruby and the Ruby on Rails framework, C#/.NET, or similar)
 
  * Experience working with technical teams to deliver user-focused services in an agile environment
 


### PR DESCRIPTION
### Background/Overview

- Currently the Software Developer and Senior Software Developer JDs have the list of programming languages listed twice
  - https://github.com/DFE-Digital/dfe-job-descriptions/blob/a1556799084b822d08f4cb0c64b720e09b0d5daa/Software%20Developers/SoftwareDeveloper.md?plain=1#L31
  - <img width="357" alt="image" src="https://user-images.githubusercontent.com/96429508/213860749-4ba98c7e-5a9e-4a55-b347-2837e4e67456.png">


### Proposed Changes

- Simple removal of duplicated entries in the list
- Update `C#.NET` to `C#/.NET` for correctness and consistency with other JDs
  - I presume omitting Ruby on Rails from the Junior Software Developer JD is deliberate - if not, given that we explicitly mention .NET, this potentially needs updating also?